### PR TITLE
Fix regex being too greedy with label

### DIFF
--- a/app/src/webhook-functions/closed-merged.ts
+++ b/app/src/webhook-functions/closed-merged.ts
@@ -68,7 +68,7 @@ export const ClosedMerged = async (client: Client, event: PullRequestClosedEvent
                     orderOfChangelog.push(fieldTitle);
                 }
                 // Truncate each line to 1002-1003 chars (depends on \n later on)
-                dataToPrint[fieldTitle].push(`- ${truncateString(data.replace(/(.*):/, "").trim(), VALUE_LENGTH)}`);
+                dataToPrint[fieldTitle].push(`- ${truncateString(data.replace(/^(.*?):/, "").trim(), VALUE_LENGTH)}`);
             }
         }
 


### PR DESCRIPTION
This PR fixes scenarios like
> add: Major Hive Buff - His Grace - Costs 0 royal resin, Can only be bought between 1:35 and 1:55 minutes (random). Spawns a cocoon of the King. The cocoon requires both comms to be held for 10 minutes. If any of the comms are lost or the cocoon itself is the destroyed it will despawn and will be on cooldown for 5-15 minutes. Can be rebought like most other buffs. All living xenos can vote for a candidate after which one of the top 2 will be randomally picked, otherwise a player is randomly selected from all living xenos > 50 hours (will fallbacks to ghosts and then again with no playtime requirements). Evacuating while the destroyer is hatching will cause it to instantly hatch.

thinking

> add: Major Hive Buff - His Grace - Costs 0 royal resin, Can only be bought between 1:35 and 1:

is the label to be truncated